### PR TITLE
Fixed title and icon margins in title bars

### DIFF
--- a/src/SimpleKit.WindowsRuntime.UI.Controls/Themes/Generic.xaml
+++ b/src/SimpleKit.WindowsRuntime.UI.Controls/Themes/Generic.xaml
@@ -64,7 +64,7 @@
 
                         <ContentPresenter
                             x:Name="TitleBarIcon"
-                            Margin="{StaticResource TitleBarIconMargin}"
+                            Margin="{ThemeResource TitleBarIconMargin}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Icon}"
@@ -73,7 +73,7 @@
                         <ContentPresenter
                             x:Name="TitleBarTitle"
                             Grid.Column="1"
-                            Margin="{StaticResource TitleBarTitleMargin}"
+                            Margin="{ThemeResource TitleBarTitleMargin}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Title}"


### PR DESCRIPTION
**Change description**
The title and icon margins in the title bar controls currently use static resources. That makes no sense and this PR fixes it.

**Added projects and types**
None.

**Modified projects and types**
- SimpleKit.WindowsRuntime.UI.Controls
  - ExtendedTitleBar
  - TitleBar

**Additional information**
Simple change, just switched to theme resources in the control templates.

**Assets**
No need.
