### PR TITLE
Expose NavigationHelper's page key

### DIFF
--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/Intellisense/SimpleKit.WindowsRuntime.UI.Navigation.xml
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/Intellisense/SimpleKit.WindowsRuntime.UI.Navigation.xml
@@ -27,6 +27,19 @@
 				Whether to enable handling for back/forward gestures and button combinations.
 			</param>
 		</member>
+		<member name="P:SimpleKit.WindowsRuntime.UI.Navigation.NavigationHelper.PageKey">
+			<summary>
+				A key used to identify the page's session state in
+				<see cref="T:SimpleKit.WindowsRuntime.UI.Navigation.SessionStateManager"/>.
+			</summary>
+			<returns>
+				The page's key.
+			</returns>
+			<remarks>
+				This property can only be used after calling
+				<see cref="M:SimpleKit.WindowsRuntime.UI.Navigation.NavigationHelper.LoadState(Windows.UI.Xaml.Navigation.NavigationMode)"/>.
+			</remarks>
+		</member>
 		<member name="M:SimpleKit.WindowsRuntime.UI.Navigation.NavigationHelper.LoadState(Windows.UI.Xaml.Navigation.NavigationMode)">
 			<summary>
 				Loads currently saved session state from

--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.cpp
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.cpp
@@ -72,12 +72,12 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 		if (const auto frame = GetPageFrame())
 		{
 			const auto frameState = SessionStateManager::SessionStateForFrame(frame);
-			m_pageKey = L"Page-" + to_hstring(frame.BackStackDepth());
+			m_PageKey = L"Page-" + to_hstring(frame.BackStackDepth());
 
 			if (navigationMode == NavigationMode::New)
 			{
 				// Clear existing state for new navigation
-				hstring nextPageKey = m_pageKey;
+				hstring nextPageKey = m_PageKey;
 				int nextPageIndex = frame.BackStackDepth();
 
 				while (frameState.HasKey(nextPageKey))
@@ -91,8 +91,8 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 			}
 
 			// If we were here before, return the preserved state
-			if (frameState.HasKey(m_pageKey))
-				return frameState.Lookup(m_pageKey).as<IMap<hstring, IInspectable>>();
+			if (frameState.HasKey(m_PageKey))
+				return frameState.Lookup(m_PageKey).as<IMap<hstring, IInspectable>>();
 		}
 
 		return nullptr;
@@ -103,7 +103,7 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 		if (const auto frame = GetPageFrame())
 		{
 			const auto frameState = SessionStateManager::SessionStateForFrame(frame);
-			frameState.Insert(m_pageKey, state);
+			frameState.Insert(m_PageKey, state);
 		}
 	}
 

--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.h
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.h
@@ -2,6 +2,8 @@
 
 #include "NavigationHelper.g.h"
 
+#include "PropertyUtils.h"
+
 namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 {
 	struct NavigationHelper : NavigationHelperT<NavigationHelper>
@@ -18,15 +20,15 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 		Windows::Foundation::Collections::IMap<hstring, Windows::Foundation::IInspectable> LoadState(Windows::UI::Xaml::Navigation::NavigationMode const& navigationMode);
 		void SaveState(Windows::Foundation::Collections::IMap<hstring, Windows::Foundation::IInspectable> const& state) const;
 
+		GET_PROPERTY(hstring, PageKey)
+
 	private:
 		~NavigationHelper();
 
+		weak_ref<Windows::UI::Xaml::Controls::Page> m_page;
 		Windows::UI::Xaml::Controls::Frame GetPageFrame() const;
 
 		bool m_useNavigationShortcuts;
-
-		weak_ref<Windows::UI::Xaml::Controls::Page> m_page;
-		hstring m_pageKey;
 
 		winrt::event_token m_backRequestedToken;
 		winrt::event_token m_loadedToken;

--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.idl
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.idl
@@ -7,6 +7,8 @@ namespace SimpleKit.WindowsRuntime.UI.Navigation
 		NavigationHelper(Windows.UI.Xaml.Controls.Page page);
 		NavigationHelper(Windows.UI.Xaml.Controls.Page page, Boolean useNavigationShortcuts);
 
+		String PageKey{ get; };
+
 		Boolean CanGoBack();
 		void GoBack();
 


### PR DESCRIPTION
**Change description**
This PR updates the `NavigationHelper` to publicly expose its page key. This key is used to retrieve session state from the `SessionStateManager`.

**Added projects and types**
None.

**Modified projects and types**
- SimpleKit.WindowsRuntime.UI.Navigation
  - NavigationHelper

**Additional information**
None.

**Assets**
None.
