### PR TITLE
Improved property macros

### DIFF
--- a/src/SimpleKit.WindowsRuntime.Shared/MidlUtils.h
+++ b/src/SimpleKit.WindowsRuntime.Shared/MidlUtils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Defines a dependency property for a runtime class.
+#define DEPENDENCY_PROPERTY(NAME, TYPE)                              \
+[noexcept]                                                           \
+static Windows.UI.Xaml.DependencyProperty NAME ## Property { get; }; \
+TYPE NAME
+
+// Defines an attached property for a runtime class.
+#define ATTACHED_PROPERTY(NAME, TYPE, TARGETTYPE)                    \
+[noexcept]                                                           \
+static Windows.UI.Xaml.DependencyProperty NAME ## Property { get; }; \
+static TYPE Get ## NAME ## (TARGETTYPE target);                      \
+static void Set ## NAME ## (TARGETTYPE target, TYPE value)

--- a/src/SimpleKit.WindowsRuntime.Shared/PropertyUtils.h
+++ b/src/SimpleKit.WindowsRuntime.Shared/PropertyUtils.h
@@ -103,12 +103,12 @@ private:                                                                      \
 __DEPENDENCY_PROPERTY_BASE(NAME, TYPE, nullptr)
 
 // Defines a dependency property with property metadata for a WinRT class.
-#define DEPENDENCY_PROPERTY_META(NAME, TYPE, DEFAULT, CHANGE_HANDLER) \
-__DEPENDENCY_PROPERTY_BASE                                            \
-(                                                                     \
-	NAME,                                                             \
-	TYPE,                                                             \
-	__DEPENDENCY_PROPERTY_METADATA(DEFAULT, CHANGE_HANDLER)           \
+#define DEPENDENCY_PROPERTY_META(NAME, TYPE, VALUE, CHANGE_HANDLER) \
+__DEPENDENCY_PROPERTY_BASE                                          \
+(                                                                   \
+	NAME,                                                           \
+	TYPE,                                                           \
+	__DEPENDENCY_PROPERTY_METADATA(VALUE, CHANGE_HANDLER)           \
 )
 
 // Defines an attached property for a WinRT class.

--- a/src/SimpleKit.WindowsRuntime.Shared/PropertyUtils.h
+++ b/src/SimpleKit.WindowsRuntime.Shared/PropertyUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// Defines a property for a WinRT class.
+// Defines a property with public getter and setter for a WinRT class.
 #define PROPERTY(TYPE, NAME)     \
 public:                          \
 	void NAME(const TYPE &value) \
@@ -9,7 +9,7 @@ public:                          \
 	}                            \
 	GET_PROPERTY(TYPE, NAME)
 
-// Defines a get-only property for a WinRT class.
+// Defines a property with a public getter for a WinRT class.
 #define GET_PROPERTY(TYPE, NAME) \
 public:                          \
 	TYPE NAME() const            \
@@ -19,7 +19,7 @@ public:                          \
 private:                         \
 	TYPE m_##NAME
 
-// Defines a static property for a WinRT class.
+// Defines a static property with public getter and setter for a WinRT class.
 #define STATIC_PROPERTY(TYPE, NAME)     \
 public:                                 \
 	static void NAME(const TYPE &value) \
@@ -28,7 +28,7 @@ public:                                 \
 	}                                   \
 	STATIC_GET_PROPERTY(TYPE, NAME)
 
-// Defines a static get-only property for a WinRT class.
+// Defines a static property with a public getter for a WinRT class.
 #define STATIC_GET_PROPERTY(TYPE, NAME) \
 public:                                 \
 	static TYPE NAME()                  \
@@ -44,11 +44,13 @@ private:                                \
 #define __XAML winrt::Windows::UI::Xaml
 #endif
 
-// Helper macro for property metadata. Do not use in authored code.
+// Helper macro for property metadata.
+// Do not use in authored code.
 #define __DEPENDENCY_PROPERTY_METADATA(VALUE, CHANGE_HANDLER) \
 __XAML::PropertyMetadata(VALUE, CHANGE_HANDLER)
 
-// Base macro for DependencyProperty registration. Do not use in authored code.
+// Base macro for DependencyProperty registration.
+// Do not use in authored code.
 #define __DEPENDENCY_PROPERTY_BASE(NAME, TYPE, METADATA)                \
 public:                                                                 \
 	static __XAML::DependencyProperty NAME##Property() noexcept         \
@@ -73,7 +75,8 @@ private:                                                                \
 			METADATA                                                    \
 		)
 
-// Base macro for attached DependencyProperty registration. Do not use in authored code.
+// Base macro for attached DependencyProperty registration.
+// Do not use in authored code.
 #define __ATTACHED_PROPERTY_BASE(NAME, TYPE, TARGETTYPE, METADATA)            \
 public:                                                                       \
 	static __XAML::DependencyProperty NAME##Property() noexcept               \

--- a/src/SimpleKit.WindowsRuntime.Shared/PropertyUtils.h
+++ b/src/SimpleKit.WindowsRuntime.Shared/PropertyUtils.h
@@ -1,173 +1,126 @@
 #pragma once
 
 // Defines a property for a WinRT class.
-#define PROPERTY(type, name)     \
+#define PROPERTY(TYPE, NAME)     \
 public:                          \
-	type name() const            \
+	void NAME(const TYPE &value) \
 	{                            \
-		return m_##name##;       \
+		m_##NAME## = value;      \
 	}                            \
-	void name(type const& value) \
-	{                            \
-		m_##name## = value;      \
-	}                            \
-private:                         \
-	type m_##name##;
+	GET_PROPERTY(TYPE, NAME)
 
 // Defines a get-only property for a WinRT class.
-#define GET_PROPERTY(type, name) \
+#define GET_PROPERTY(TYPE, NAME) \
 public:                          \
-	type name() const            \
+	TYPE NAME() const            \
 	{                            \
-		return m_##name##;       \
+		return m_##NAME##;       \
 	}                            \
 private:                         \
-	void name(type const& value) \
-	{                            \
-		m_##name## = value;      \
-	}                            \
-	type m_##name##;
+	TYPE m_##NAME
 
 // Defines a static property for a WinRT class.
-#define STATIC_PROPERTY(type, name)     \
+#define STATIC_PROPERTY(TYPE, NAME)     \
 public:                                 \
-	static type name()                  \
+	static void NAME(const TYPE &value) \
 	{                                   \
-		return m_##name##;              \
+		m_##NAME = value;               \
 	}                                   \
-	static void name(type const& value) \
-	{                                   \
-		m_##name## = value;             \
-	}                                   \
-private:                                \
-	static type m_##name##;
+	STATIC_GET_PROPERTY(TYPE, NAME)
 
 // Defines a static get-only property for a WinRT class.
-#define STATIC_GET_PROPERTY(type, name) \
+#define STATIC_GET_PROPERTY(TYPE, NAME) \
 public:                                 \
-	static type name()                  \
+	static TYPE NAME()                  \
 	{                                   \
-		return m_##name##;              \
+		return m_##NAME##;              \
 	}                                   \
 private:                                \
-	static void name(type const& value) \
-	{                                   \
-		m_##name## = value;             \
-	}                                   \
-	static type m_##name##;
+	static TYPE m_##NAME
+
+#ifdef USE_WINUI3
+#define __XAML winrt::Microsoft::UI::Xaml
+#else
+#define __XAML winrt::Windows::UI::Xaml
+#endif
+
+// Helper macro for property metadata. Do not use in authored code.
+#define __DEPENDENCY_PROPERTY_METADATA(VALUE, CHANGE_HANDLER) \
+__XAML::PropertyMetadata(VALUE, CHANGE_HANDLER)
+
+// Base macro for DependencyProperty registration. Do not use in authored code.
+#define __DEPENDENCY_PROPERTY_BASE(NAME, TYPE, METADATA)                \
+public:                                                                 \
+	static __XAML::DependencyProperty NAME##Property() noexcept         \
+	{                                                                   \
+		return m_##NAME##Property;                                      \
+	}                                                                   \
+	TYPE NAME() const                                                   \
+	{                                                                   \
+		return winrt::unbox_value<TYPE>(GetValue(m_##NAME##Property));  \
+	}                                                                   \
+	void NAME(const TYPE &value) const                                  \
+	{                                                                   \
+		SetValue(m_##NAME##Property, winrt::box_value(value));          \
+	}                                                                   \
+private:                                                                \
+	inline static __XAML::DependencyProperty const m_##NAME##Property = \
+		__XAML::DependencyProperty::Register                            \
+		(                                                               \
+			L#NAME,                                                     \
+			winrt::xaml_typename<TYPE>(),                               \
+			winrt::xaml_typename<class_type>(),                         \
+			METADATA                                                    \
+		)
+
+// Base macro for attached DependencyProperty registration. Do not use in authored code.
+#define __ATTACHED_PROPERTY_BASE(NAME, TYPE, TARGETTYPE, METADATA)            \
+public:                                                                       \
+	static __XAML::DependencyProperty NAME##Property() noexcept               \
+	{                                                                         \
+		return m_##NAME##Property;                                            \
+	}                                                                         \
+	static TYPE Get##NAME(const TARGETTYPE &target)                           \
+	{                                                                         \
+		return winrt::unbox_value<TYPE>(target.GetValue(m_##NAME##Property)); \
+	}                                                                         \
+	static void Set##NAME(const TARGETTYPE &target, const TYPE &value)        \
+	{                                                                         \
+		target.SetValue(m_##NAME##Property, winrt::box_value(value));         \
+	}                                                                         \
+private:                                                                      \
+	inline static __XAML::DependencyProperty const m_##NAME##Property =       \
+		__XAML::DependencyProperty::RegisterAttached                          \
+		(                                                                     \
+			L#NAME,                                                           \
+			winrt::xaml_typename<TYPE>(),                                     \
+			winrt::xaml_typename<class_type>(),                               \
+			METADATA                                                          \
+		)
 
 // Defines a dependency property for a WinRT class.
-#define DEPENDENCY_PROPERTY(name, type, ownerType)                                   \
-public:                                                                              \
-	static winrt::Windows::UI::Xaml::DependencyProperty name##Property()             \
-	{                                                                                \
-		return m_##name##Property();                                                 \
-	}                                                                                \
-	type name() const                                                                \
-	{                                                                                \
-		return winrt::unbox_value<type>(GetValue(m_##name##Property()));             \
-	}                                                                                \
-	void name(type const& value)                                                     \
-	{                                                                                \
-		SetValue(m_##name##Property(), winrt::box_value(value));                     \
-	}                                                                                \
-private:                                                                             \
-	static inline winrt::Windows::UI::Xaml::DependencyProperty& m_##name##Property() \
-	{                                                                                \
-		static auto m_##name## =                                                     \
-			winrt::Windows::UI::Xaml::DependencyProperty::Register                   \
-			(                                                                        \
-				L#name,                                                              \
-				winrt::xaml_typename<##type##>(),                                    \
-				winrt::xaml_typename<##ownerType##>(),                               \
-				winrt::Windows::UI::Xaml::PropertyMetadata{ nullptr }                \
-			);                                                                       \
-		return m_##name##;                                                           \
-	}
+#define DEPENDENCY_PROPERTY(NAME, TYPE)         \
+__DEPENDENCY_PROPERTY_BASE(NAME, TYPE, nullptr)
 
 // Defines a dependency property with property metadata for a WinRT class.
-#define DEPENDENCY_PROPERTY_META(name, type, ownerType, changeHandler, defaultVal)        \
-public:                                                                                   \
-	static winrt::Windows::UI::Xaml::DependencyProperty name##Property()                  \
-	{                                                                                     \
-		return m_##name##Property();                                                      \
-	}                                                                                     \
-	type name() const                                                                     \
-	{                                                                                     \
-		return winrt::unbox_value<type>(GetValue(m_##name##Property()));                  \
-	}                                                                                     \
-	void name(type const& value)                                                          \
-	{                                                                                     \
-		SetValue(m_##name##Property(), winrt::box_value(value));                          \
-	}                                                                                     \
-private:                                                                                  \
-	static inline winrt::Windows::UI::Xaml::DependencyProperty& m_##name##Property()      \
-	{                                                                                     \
-		static auto m_##name## =                                                          \
-			winrt::Windows::UI::Xaml::DependencyProperty::Register                        \
-			(                                                                             \
-				L#name,                                                                   \
-				winrt::xaml_typename<##type##>(),                                         \
-				winrt::xaml_typename<##ownerType##>(),                                    \
-				winrt::Windows::UI::Xaml::PropertyMetadata(defaultVal, ##changeHandler##) \
-			);                                                                            \
-		return m_##name##;                                                                \
-	}
+#define DEPENDENCY_PROPERTY_META(NAME, TYPE, DEFAULT, CHANGE_HANDLER) \
+__DEPENDENCY_PROPERTY_BASE                                            \
+(                                                                     \
+	NAME,                                                             \
+	TYPE,                                                             \
+	__DEPENDENCY_PROPERTY_METADATA(DEFAULT, CHANGE_HANDLER)           \
+)
 
 // Defines an attached property for a WinRT class.
-#define ATTACHED_PROPERTY(name, type, ownerType, targetType)                         \
-public:                                                                              \
-	static winrt::Windows::UI::Xaml::DependencyProperty name##Property()             \
-	{                                                                                \
-		return m_##name##Property();                                                 \
-	}                                                                                \
-	static type Get##name(targetType const& target)                                  \
-	{                                                                                \
-		return winrt::unbox_value<type>(target.GetValue(m_##name##Property()));      \
-	}                                                                                \
-	static void Set##name(targetType const& target, type const& value)               \
-	{                                                                                \
-		target.SetValue(m_##name##Property(), winrt::box_value(value));              \
-	}                                                                                \
-private:                                                                             \
-	static inline winrt::Windows::UI::Xaml::DependencyProperty& m_##name##Property() \
-	{                                                                                \
-		static auto m_##name## =                                                     \
-			winrt::Windows::UI::Xaml::DependencyProperty::RegisterAttached           \
-			(                                                                        \
-				L#name,                                                              \
-				winrt::xaml_typename<##type##>(),                                    \
-				winrt::xaml_typename<##ownerType##>(),                               \
-				winrt::Windows::UI::Xaml::PropertyMetadata{ nullptr }                \
-			);                                                                       \
-		return m_##name##;                                                           \
-	}
+#define ATTACHED_PROPERTY(NAME, TYPE, TARGETTYPE)         \
+__ATTACHED_PROPERTY_BASE(NAME, TYPE, TARGETTYPE, nullptr)
 
 // Defines an attached property with property metadata for a WinRT class.
-#define ATTACHED_PROPERTY_META(name, type, ownerType, targetType, changeHandler, defaultVal)  \
-public:                                                                                       \
-	static winrt::Windows::UI::Xaml::DependencyProperty name##Property()                      \
-	{                                                                                         \
-		return m_##name##Property();                                                          \
-	}                                                                                         \
-	static type Get##name(targetType const& target)                                           \
-	{                                                                                         \
-		return winrt::unbox_value<type>(target.GetValue(m_##name##Property()));               \
-	}                                                                                         \
-	static void Set##name(targetType const& target, type const& value)                        \
-	{                                                                                         \
-		target.SetValue(m_##name##Property(), winrt::box_value(value));                       \
-	}                                                                                         \
-private:                                                                                      \
-	static inline winrt::Windows::UI::Xaml::DependencyProperty& m_##name##Property()          \
-	{                                                                                         \
-		static auto m_##name## =                                                              \
-			winrt::Windows::UI::Xaml::DependencyProperty::RegisterAttached                    \
-			(                                                                                 \
-				L#name,                                                                       \
-				winrt::xaml_typename<##type##>(),                                             \
-				winrt::xaml_typename<##ownerType##>(),                                        \
-				winrt::Windows::UI::Xaml::PropertyMetadata(##defaultVal##, ##changeHandler##) \
-			);                                                                                \
-		return m_##name##;                                                                    \
-	}
+#define ATTACHED_PROPERTY_META(NAME, TYPE, TARGETTYPE, VALUE, CHANGE_HANDLER) \
+__ATTACHED_PROPERTY_BASE                                                      \
+(                                                                             \
+	NAME,                                                                     \
+	TYPE,                                                                     \
+	TARGETTYPE,                                                               \
+	__DEPENDENCY_PROPERTY_METADATA(VALUE, CHANGE_HANDLER)                     \
+)

--- a/src/SimpleKit.WindowsRuntime.Shared/SimpleKit.WindowsRuntime.Shared.vcxitems
+++ b/src/SimpleKit.WindowsRuntime.Shared/SimpleKit.WindowsRuntime.Shared.vcxitems
@@ -14,6 +14,7 @@
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)MidlUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PropertyUtils.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SimpleKit.WindowsRuntime.Shared/SimpleKit.WindowsRuntime.Shared.vcxitems
+++ b/src/SimpleKit.WindowsRuntime.Shared/SimpleKit.WindowsRuntime.Shared.vcxitems
@@ -17,7 +17,4 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)MidlUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PropertyUtils.h" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)cpp.hint" />
-  </ItemGroup>
 </Project>

--- a/src/SimpleKit.WindowsRuntime.Shared/cpp.hint
+++ b/src/SimpleKit.WindowsRuntime.Shared/cpp.hint
@@ -1,6 +1,0 @@
-#define PROPERTY(type, name)
-#define GET_PROPERTY(type, name)
-#define STATIC_PROPERTY(type, name)
-#define STATIC_GET_PROPERTY(type, name)
-#define DEPENDENCY_PROPERTY(type, name)
-#define ATTACHED_PROPERTY(targetType, type, name)

--- a/src/SimpleKit.WindowsRuntime.UI.Controls/TitleBar.cpp
+++ b/src/SimpleKit.WindowsRuntime.UI.Controls/TitleBar.cpp
@@ -20,9 +20,6 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Controls::implementation
 	{
 		DefaultStyleKey(winrt::box_value(this->GetRuntimeClassName()));
 
-		m_IconProperty();
-		m_TitleProperty();
-
 		m_unloadedToken = Unloaded
 		(
 			{ this, &TitleBar::OnUnloaded }

--- a/src/SimpleKit.WindowsRuntime.UI.Controls/TitleBar.h
+++ b/src/SimpleKit.WindowsRuntime.UI.Controls/TitleBar.h
@@ -8,6 +8,14 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Controls::implementation
 {
 	struct TitleBar : TitleBarT<TitleBar>
 	{
+	private:
+		static void OnIconPropertyChanged
+		(
+			Windows::UI::Xaml::DependencyObject const& sender,
+			Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& args
+		);
+
+	public:
 		TitleBar();
 
 		void SetTitleBarForCurrentView();
@@ -16,26 +24,19 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Controls::implementation
 		DEPENDENCY_PROPERTY
 		(
 			Title,
-			Windows::Foundation::IInspectable,
-			Controls::TitleBar
-		)
+			Windows::Foundation::IInspectable
+		);
 
 		DEPENDENCY_PROPERTY_META
 		(
 			Icon,
 			Windows::UI::Xaml::Controls::IconElement,
-			Controls::TitleBar,
-			OnIconPropertyChanged,
-			nullptr
-		)
+			nullptr,
+			OnIconPropertyChanged
+		);
 
 	private:
 		void UpdateIcon() const;
-		static void OnIconPropertyChanged
-		(
-			Windows::UI::Xaml::DependencyObject const& sender,
-			Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& args
-		);
 
 		Windows::ApplicationModel::Core::CoreApplicationViewTitleBar::IsVisibleChanged_revoker m_visibleChangedToken;
 		void OnVisibleChanged

--- a/src/SimpleKit.WindowsRuntime.UI.Controls/TitleBar.idl
+++ b/src/SimpleKit.WindowsRuntime.UI.Controls/TitleBar.idl
@@ -1,3 +1,5 @@
+#include "../SimpleKit.WindowsRuntime.Shared/MidlUtils.h"
+
 namespace SimpleKit.WindowsRuntime.UI.Controls
 {
 	[default_interface]
@@ -8,10 +10,7 @@ namespace SimpleKit.WindowsRuntime.UI.Controls
 		TitleBar();
 		void SetTitleBarForCurrentView();
 
-		static Windows.UI.Xaml.DependencyProperty TitleProperty{ get; };
-		Object Title{ get; set; };
-
-		static Windows.UI.Xaml.DependencyProperty IconProperty{ get; };
-		Windows.UI.Xaml.Controls.IconElement Icon{ get; set; };
+		DEPENDENCY_PROPERTY(Title, Object);
+		DEPENDENCY_PROPERTY(Icon, Windows.UI.Xaml.Controls.IconElement);
 	}
 }

--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.h
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/NavigationHelper.h
@@ -20,7 +20,7 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 		Windows::Foundation::Collections::IMap<hstring, Windows::Foundation::IInspectable> LoadState(Windows::UI::Xaml::Navigation::NavigationMode const& navigationMode);
 		void SaveState(Windows::Foundation::Collections::IMap<hstring, Windows::Foundation::IInspectable> const& state) const;
 
-		GET_PROPERTY(hstring, PageKey)
+		GET_PROPERTY(hstring, PageKey);
 
 	private:
 		~NavigationHelper();

--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/SessionStateManager.h
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/SessionStateManager.h
@@ -8,6 +8,10 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 {
 	struct SessionStateManager : SessionStateManagerT<SessionStateManager>
 	{
+	private:
+		static void OnSessionKeyAdded(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
+
+	public:
 		SessionStateManager() = default;
 		static void Initialize();
 
@@ -30,16 +34,14 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::Navigation::implementation
 		(
 			SessionKey,
 			hstring,
-			Navigation::SessionStateManager,
 			Windows::UI::Xaml::Controls::Frame,
-			OnSessionKeyAdded,
-			nullptr
-		)
+			nullptr,
+			OnSessionKeyAdded
+		);
 
 	private:
 		inline static const hstring m_sessionStateFilename = L"_sessionState.dat";
 
-		static void OnSessionKeyAdded(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
 		static void RestoreFrameNavigationState(Windows::UI::Xaml::Controls::Frame const& frame);
 		static void SaveFrameNavigationState(Windows::UI::Xaml::Controls::Frame const& frame);
 

--- a/src/SimpleKit.WindowsRuntime.UI.Navigation/SessionStateManager.idl
+++ b/src/SimpleKit.WindowsRuntime.UI.Navigation/SessionStateManager.idl
@@ -1,3 +1,5 @@
+#include "../SimpleKit.WindowsRuntime.Shared/MidlUtils.h"
+
 namespace SimpleKit.WindowsRuntime.UI.Navigation
 {
 	[default_interface]
@@ -13,9 +15,7 @@ namespace SimpleKit.WindowsRuntime.UI.Navigation
 		static Windows.Foundation.IAsyncAction RestoreAsync();
 		static Windows.Foundation.IAsyncAction RestoreAsync(String sessionBaseKey);
 
-		static Windows.UI.Xaml.DependencyProperty SessionKeyProperty { get; };
-		static String GetSessionKey(Windows.UI.Xaml.Controls.Frame target);
-		static void SetSessionKey(Windows.UI.Xaml.Controls.Frame target, String value);
+		ATTACHED_PROPERTY(SessionKey, String, Windows.UI.Xaml.Controls.Frame);
 
 		static void RegisterFrame(Windows.UI.Xaml.Controls.Frame frame, String sessionStateKey);
 		static void RegisterFrame(Windows.UI.Xaml.Controls.Frame frame, String sessionStateKey, String sessionBaseKey);

--- a/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.h
+++ b/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.h
@@ -10,6 +10,10 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::ViewManagement::implementation
 {
 	struct ViewHelpers : ViewHelpersT<ViewHelpers>
 	{
+	private:
+		static void OnViewTitleChanged(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
+
+	public:
 		ViewHelpers() = default;
 
 		static Windows::Foundation::IAsyncOperation<Windows::UI::ViewManagement::ApplicationView>
@@ -22,18 +26,16 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::ViewManagement::implementation
 		(
 			ViewTitle,
 			hstring,
-			ViewManagement::ViewHelpers,
 			Windows::UI::Xaml::Controls::Page,
-			OnViewTitleChanged,
-			nullptr
-		)
+			nullptr,
+			OnViewTitleChanged
+		);
 
 	private:
 		static std::map<int, winrt::weak_ref<Windows::UI::Xaml::Controls::Frame>> m_frames;
 		static std::map<int, winrt::event_token> m_tokens;
 
 		static void OnViewConsolidated(Windows::UI::ViewManagement::ApplicationView const& sender, Windows::UI::ViewManagement::ApplicationViewConsolidatedEventArgs const& args);
-		static void OnViewTitleChanged(Windows::UI::Xaml::DependencyObject const& d, Windows::UI::Xaml::DependencyPropertyChangedEventArgs const& e);
 	};
 }
 

--- a/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.idl
+++ b/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.idl
@@ -1,3 +1,5 @@
+#include "../SimpleKit.WindowsRuntime.Shared/MidlUtils.h"
+
 namespace SimpleKit.WindowsRuntime.UI.ViewManagement
 {
 	[default_interface]
@@ -9,8 +11,6 @@ namespace SimpleKit.WindowsRuntime.UI.ViewManagement
 		static Windows.Foundation.IAsyncOperation<Windows.UI.ViewManagement.ApplicationView> CreateNewViewAsync(Windows.UI.Xaml.Interop.TypeName sourcePageType);
 		static Windows.Foundation.IAsyncOperation<Boolean> ShowNewViewAsync(Windows.UI.Xaml.Interop.TypeName sourcePageType);
 
-		static Windows.UI.Xaml.DependencyProperty ViewTitleProperty { get; };
-		static String GetViewTitle(Windows.UI.Xaml.Controls.Page target);
-		static void SetViewTitle(Windows.UI.Xaml.Controls.Page target, String value);
+		ATTACHED_PROPERTY(ViewTitle, String, Windows.UI.Xaml.Controls.Page);
 	}
 }


### PR DESCRIPTION
**Change description**
This pull request improves the macros used for `DependencyProperty` registration, and makes a few improvements for other property macros. It also adds macros for use in IDL.

**Modified projects and types**
- All projects using dependency properties
- The shared project

**Additional information**
The new macros make use of `noexcept` where useful, remove the need for specifying an owner type, and their implementation is cleaner. For IDL, the full relative path to the `MidlUtils.h` header must be specified when including it - that is, going back a directory, getting into the shared project's folder, and including the header. Unsure of whether there's a fix for this:

```C
#include "../SimpleKit.WindowsRuntime.Shared/MidlUtils.h"
```

**Assets**
None.
