### PR TITLE
Switched to `CoreWindow.Close()` for `ViewHelpers` consolidation handling

### DIFF
--- a/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.cpp
+++ b/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.cpp
@@ -33,10 +33,7 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::ViewManagement::implementation
 				curr.Activate();
 
 				newView = ApplicationView::GetForCurrentView();
-				const auto id = newView.Id();
-
-				m_frames[id] = winrt::make_weak(frame);
-				m_tokens[id] = newView.Consolidated(OnViewConsolidated);
+				m_tokens[newView.Id()] = newView.Consolidated(OnViewConsolidated);
 			});
 
 		co_return newView;
@@ -52,15 +49,10 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::ViewManagement::implementation
 	{
 		const auto id = sender.Id();
 
-		// Set the frame's content to null when the view's consolidated,
-		// which prevents memory leaks
-		if (const auto frame = m_frames[id].get())
-			frame.Content(nullptr);
-
 		sender.Consolidated(m_tokens[id]);
-
-		m_frames.erase(id);
 		m_tokens.erase(id);
+
+		CoreWindow::GetForCurrentThread().Close();
 	}
 
 	void ViewHelpers::OnViewTitleChanged(DependencyObject const&, DependencyPropertyChangedEventArgs const& e)
@@ -73,6 +65,5 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::ViewManagement::implementation
 		}
 	}
 
-	std::map<int, winrt::weak_ref<Frame>> ViewHelpers::m_frames = std::map<int, winrt::weak_ref<Frame>>();
 	std::map<int, winrt::event_token> ViewHelpers::m_tokens = std::map<int, winrt::event_token>();
 }

--- a/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.h
+++ b/src/SimpleKit.WindowsRuntime.UI.ViewManagement/ViewHelpers.h
@@ -32,7 +32,6 @@ namespace winrt::SimpleKit::WindowsRuntime::UI::ViewManagement::implementation
 		);
 
 	private:
-		static std::map<int, winrt::weak_ref<Windows::UI::Xaml::Controls::Frame>> m_frames;
 		static std::map<int, winrt::event_token> m_tokens;
 
 		static void OnViewConsolidated(Windows::UI::ViewManagement::ApplicationView const& sender, Windows::UI::ViewManagement::ApplicationViewConsolidatedEventArgs const& args);


### PR DESCRIPTION
**Change description**
This PR makes it so, instead of setting a view's root Frame to null when it is consolidated, the associated `CoreWindow` gets closed. This is the correct way of doing it.

**Modified projects and types**
- SimpleKit.WindowsRuntime.UI.ViewManagement
  - ViewHelpers

**Additional information**
Thanks to https://stackoverflow.com/questions/42806422/c-sharp-uwp-new-view-memory-leak

**Assets**
None.
